### PR TITLE
A possible more generic way forward for integration with TypeChat.

### DIFF
--- a/CoffeeShop.ServiceInterface/AppConfig.cs
+++ b/CoffeeShop.ServiceInterface/AppConfig.cs
@@ -4,7 +4,7 @@ public class AppConfig
 {
     public string Project { get; set; }
     public string Location { get; set; }
-    public SiteConfig CoffeeShop { get; set; }
+    public SiteConfig SiteConfig { get; set; }
     public string NodePath { get; set; }
     public string? FfmpegPath { get; set; }
     public string? WhisperPath { get; set; }

--- a/CoffeeShop.ServiceInterface/GptCoffeeShop.cs
+++ b/CoffeeShop.ServiceInterface/GptCoffeeShop.cs
@@ -10,32 +10,84 @@ using ServiceStack.Text;
 
 namespace CoffeeShop.ServiceInterface;
 
-public interface IGptCoffeeShop
+public interface ITypeChatProvider<T>
 {
-    Task<string> GetSchemaAsync(IDbConnection db, CancellationToken token=default);
-    Task<string> CreatePromptAsync(IDbConnection db, string request, CancellationToken token=default);
-    Task<string> OrderAsync(IDbConnection db, string request, CancellationToken token=default);
+    Task<string> GetSchemaAsync(IGptRequest<T> request, CancellationToken token = default);
+    Task<string> CreatePromptAsync(IGptRequest<T> request, CancellationToken token=default);
+    
+    Task<T> ProcessAsync(IGptRequest<T> request, CancellationToken token=default);
 }
 
-public abstract class GptCoffeeShopBase : IGptCoffeeShop
+public class NodeTypeChatProvider<T> : ChatProviderBase<T>
+{
+    public NodeTypeChatProvider(AppConfig config) : base(config) {}
+
+    public override async Task<T> ProcessAsync(IGptRequest<T> request, CancellationToken token = default)
+    {
+        var schemaPath = Config.SiteConfig.GptPath.CombineWith("schema.ts");
+        var schema = await GetSchemaAsync(request, token);
+        await File.WriteAllTextAsync(schemaPath, schema, token);
+
+        var shellRequest = request.UserRequest.Replace('"', '\'');
+        var processInfo = new ProcessStartInfo
+        {
+            WorkingDirectory = Environment.CurrentDirectory,
+            FileName = Config.NodePath,
+            Arguments = $"typechat.mjs ./{schemaPath} \"{shellRequest}\" {typeof(T).Name}",
+        };
+        if (Env.IsWindows)
+            processInfo = processInfo.ConvertToCmdExec();
+
+        var sb = StringBuilderCache.Allocate();
+        var sbError = StringBuilderCacheAlt.Allocate();
+        await ProcessUtils.RunAsync(processInfo, Config.NodeProcessTimeoutMs,
+            onOut: data => sb.AppendLine(data),
+            onError: data => sbError.AppendLine(data));
+
+        if (sbError.Length > 0)
+            throw new Exception($"Error running node {StringBuilderCacheAlt.ReturnAndFree(sbError)}");
+
+        var result = StringBuilderCache.ReturnAndFree(sb);
+        return result.FromJson<T>();
+    }
+}
+
+public class KernelChatProvider<T> : ChatProviderBase<T>
+{
+    public IKernel Kernel { get; set; }
+    
+    public KernelChatProvider(AppConfig config, IKernel kernel) : base(config)
+    {
+        Kernel = kernel;
+    }
+
+    public override async Task<T> ProcessAsync(IGptRequest<T> request, CancellationToken token = default)
+    {
+        var prompt = await CreatePromptAsync(request, token);
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage(prompt);
+        var chatCompletionService = Kernel.GetService<IChatCompletion>();
+        var result = await chatCompletionService.GenerateMessageAsync(chatHistory, new ChatRequestSettings {
+            Temperature = 0.0,
+        }, cancellationToken: token);
+        return result.FromJson<T>();
+    }
+}
+
+public abstract class ChatProviderBase<T> : ITypeChatProvider<T>
 {
     protected AppConfig Config { get; }
 
-    protected GptCoffeeShopBase(AppConfig config)
+    protected ChatProviderBase(AppConfig config)
     {
         Config = config;
     }
 
-    public virtual async Task<string> GetSchemaAsync(IDbConnection db, CancellationToken token = default)
+    public virtual async Task<string> GetSchemaAsync(IGptRequest<T> request, CancellationToken token = default)
     {
-        var file = new FileInfo(Config.CoffeeShop.GptPath.CombineWith("schema.ss"));
+        var file = new FileInfo(Config.SiteConfig.GptPath.CombineWith("schema.ss"));
         if (file == null)
-            throw HttpError.NotFound($"{Config.CoffeeShop.GptPath}/schema.ss not found");
-
-        var categories = await db.LoadSelectAsync(db.From<Category>(), token:token);
-        var options = await db.SelectAsync<Option>(token: token);
-        var optionsMap = options.ToDictionary(x => x.Id);
-        var optionQuantities = await db.SelectAsync<OptionQuantity>(token: token);
+            throw HttpError.NotFound($"{Config.SiteConfig.GptPath}/schema.ss not found");
 
         var tpl = await file.ReadAllTextAsync(token: token);
         var context = new ScriptContext {
@@ -44,24 +96,18 @@ public abstract class GptCoffeeShopBase : IGptCoffeeShop
 
         var output = await new PageResult(context.OneTimePage(tpl))
         {
-            Args =
-            {
-                [nameof(categories)] = categories,
-                [nameof(options)] = options,
-                [nameof(optionsMap)] = optionsMap,
-                [nameof(optionQuantities)] = optionQuantities,
-            },
+            Args = request.PromptContext ?? new Dictionary<string, object>()
         }.RenderScriptAsync(token: token);
         return output;
     }
 
-    public virtual async Task<string> CreatePromptAsync(IDbConnection db, string request, CancellationToken token = default)
+    public virtual async Task<string> CreatePromptAsync(IGptRequest<T> request, CancellationToken token = default)
     {
-        var file = new FileInfo(Config.CoffeeShop.GptPath.CombineWith("prompt.ss"));
+        var file = new FileInfo(Config.SiteConfig.GptPath.CombineWith("prompt.ss"));
         if (file == null)
-            throw HttpError.NotFound($"{Config.CoffeeShop.GptPath}/prompt.ss not found");
+            throw HttpError.NotFound($"{Config.SiteConfig.GptPath}/prompt.ss not found");
         
-        var schema = await GetSchemaAsync(db, token: token);
+        var schema = await GetSchemaAsync(request, token: token);
         var tpl = await file.ReadAllTextAsync(token: token);
         var context = new ScriptContext {
             Plugins = { new TypeScriptPlugin() }
@@ -79,61 +125,5 @@ public abstract class GptCoffeeShopBase : IGptCoffeeShop
         return prompt;
     }
 
-    public abstract Task<string> OrderAsync(IDbConnection db, string request, CancellationToken token = default);
-}
-
-public class NodeTypeChatGptCoffeeShop : GptCoffeeShopBase
-{
-    public NodeTypeChatGptCoffeeShop(AppConfig config) : base(config) {}
-
-    public override async Task<string> OrderAsync(IDbConnection db, string request, CancellationToken token = default)
-    {
-        var schemaPath = Config.CoffeeShop.GptPath.CombineWith("schema.ts");
-        var schema = await GetSchemaAsync(db, token);
-        await File.WriteAllTextAsync(schemaPath, schema, token);
-
-        var shellRequest = request.Replace('"', '\'');
-        var processInfo = new ProcessStartInfo
-        {
-            WorkingDirectory = Environment.CurrentDirectory,
-            FileName = Config.NodePath,
-            Arguments = $"typechat.mjs ./{schemaPath} \"{shellRequest}\"",
-        };
-        if (Env.IsWindows)
-            processInfo = processInfo.ConvertToCmdExec();
-
-        var sb = StringBuilderCache.Allocate();
-        var sbError = StringBuilderCacheAlt.Allocate();
-        await ProcessUtils.RunAsync(processInfo, Config.NodeProcessTimeoutMs,
-            onOut: data => sb.AppendLine(data),
-            onError: data => sbError.AppendLine(data));
-
-        if (sbError.Length > 0)
-            throw new Exception($"Error running node {StringBuilderCacheAlt.ReturnAndFree(sbError)}");
-
-        var result = StringBuilderCache.ReturnAndFree(sb);
-        return result;
-    }
-}
-
-public class KernelGptCoffeeShop : GptCoffeeShopBase
-{
-    public IKernel Kernel { get; set; }
-    
-    public KernelGptCoffeeShop(AppConfig config, IKernel kernel) : base(config)
-    {
-        Kernel = kernel;
-    }
-
-    public override async Task<string> OrderAsync(IDbConnection db, string request, CancellationToken token = default)
-    {
-        var prompt = await CreatePromptAsync(db, request, token);
-        var chatHistory = new ChatHistory();
-        chatHistory.AddUserMessage(prompt);
-        var chatCompletionService = Kernel.GetService<IChatCompletion>();
-        var result = await chatCompletionService.GenerateMessageAsync(chatHistory, new ChatRequestSettings {
-            Temperature = 0.0,
-        }, cancellationToken: token);
-        return result;
-    }
+    public abstract Task<T> ProcessAsync(IGptRequest<T> request, CancellationToken token = default);
 }

--- a/CoffeeShop.ServiceInterface/SpeechToText.cs
+++ b/CoffeeShop.ServiceInterface/SpeechToText.cs
@@ -39,7 +39,7 @@ public class GoogleCloudSpeechToText : ISpeechToText
         {
             await SpeechClient.DeletePhraseSetAsync(new DeletePhraseSetRequest
             {
-                PhraseSetName = new PhraseSetName(Config.Project, Config.Location, Config.CoffeeShop.PhraseSetId)
+                PhraseSetName = new PhraseSetName(Config.Project, Config.Location, Config.SiteConfig.PhraseSetId)
             });
         }
         catch (Exception ignoreNonExistingPhraseSet) {}
@@ -47,7 +47,7 @@ public class GoogleCloudSpeechToText : ISpeechToText
         await SpeechClient.CreatePhraseSetAsync(new CreatePhraseSetRequest
         {
             Parent = $"projects/{Config.Project}/locations/{Config.Location}",
-            PhraseSetId = Config.CoffeeShop.PhraseSetId,
+            PhraseSetId = Config.SiteConfig.PhraseSetId,
             PhraseSet = new PhraseSet
             {
                 Phrases =
@@ -61,7 +61,7 @@ public class GoogleCloudSpeechToText : ISpeechToText
         {
             await SpeechClient.DeleteRecognizerAsync(new DeleteRecognizerRequest
             {
-                RecognizerName = new RecognizerName(Config.Project, Config.Location, Config.CoffeeShop.RecognizerId)
+                RecognizerName = new RecognizerName(Config.Project, Config.Location, Config.SiteConfig.RecognizerId)
             });
         }
         catch (Exception ignoreNonExistingRecognizer) {}
@@ -69,7 +69,7 @@ public class GoogleCloudSpeechToText : ISpeechToText
         await SpeechClient.CreateRecognizerAsync(new CreateRecognizerRequest
         {
             Parent = $"projects/{Config.Project}/locations/{Config.Location}",
-            RecognizerId = Config.CoffeeShop.RecognizerId,
+            RecognizerId = Config.SiteConfig.RecognizerId,
             Recognizer = new Recognizer
             {
                 DefaultRecognitionConfig = new RecognitionConfig
@@ -83,7 +83,7 @@ public class GoogleCloudSpeechToText : ISpeechToText
                         {
                             new SpeechAdaptation.Types.AdaptationPhraseSet
                             {
-                                PhraseSet = $"projects/{Config.Project}/locations/{Config.Location}/phraseSets/{Config.CoffeeShop.PhraseSetId}"
+                                PhraseSet = $"projects/{Config.Project}/locations/{Config.Location}/phraseSets/{Config.SiteConfig.PhraseSetId}"
                             }
                         }
                     }
@@ -96,8 +96,8 @@ public class GoogleCloudSpeechToText : ISpeechToText
     {
         var response = await SpeechClient.RecognizeAsync(new RecognizeRequest
         {
-            Recognizer = $"projects/{Config.Project}/locations/{Config.Location}/recognizers/{Config.CoffeeShop.RecognizerId}",
-            Uri = $"gs://{Config.CoffeeShop.Bucket}".CombineWith(recordingPath)
+            Recognizer = $"projects/{Config.Project}/locations/{Config.Location}/recognizers/{Config.SiteConfig.RecognizerId}",
+            Uri = $"gs://{Config.SiteConfig.Bucket}".CombineWith(recordingPath)
         });
 
         var alt = response.Results[0].Alternatives[0];

--- a/CoffeeShop.ServiceModel/CoffeeShop.cs
+++ b/CoffeeShop.ServiceModel/CoffeeShop.cs
@@ -281,6 +281,11 @@ public class CreateCoffeeShopChat : ICreateDb<Chat>, IReturn<Chat>
     public string Request { get; set; }
 }
 
+public class ProcessCartRequest : GptRequestBase<Cart>
+{
+
+}
+
 /* GPT Models */
 public class Cart
 {
@@ -297,13 +302,13 @@ public class ProductItem
 {
     public string Type { get; set; }
     public string Name { get; set; }
-    public List<ProductOption> Options { get; set; }
+    public string Temperature { get; set; }
+    public string Size { get; set; }
+    public string OptionQuantity { get; set; }
 }
 public class ProductOption
 {
     public string Type { get; set; }
     public string Name { get; set; }
-    public string Temperature { get; set; }
-    public string Size { get; set; }
-    public string OptionQuantity { get; set; }
+
 }

--- a/CoffeeShop.ServiceModel/GptRequest.cs
+++ b/CoffeeShop.ServiceModel/GptRequest.cs
@@ -1,0 +1,15 @@
+﻿using ServiceStack;
+
+namespace CoffeeShop.ServiceModel;
+
+public class GptRequestBase<T> : IGptRequest<T>
+{
+    public string UserRequest { get; set; }
+    public Dictionary<string,object>? PromptContext { get; set; }
+}
+
+public interface IGptRequest<T> : IReturn<T>
+{
+    string UserRequest { get; set; }
+    Dictionary<string,object>? PromptContext { get; set; }
+}

--- a/CoffeeShop.Tests/UnitTest.cs
+++ b/CoffeeShop.Tests/UnitTest.cs
@@ -18,4 +18,17 @@ public class UnitTest
 
     [OneTimeTearDown]
     public void OneTimeTearDown() => appHost.Dispose();
+
+    [Test]
+    public void Can_serialized_a_cart_with_iced_coffee()
+    {
+        var json =
+            "{\n  \"items\": [\n    {\n      \"type\": \"lineitem\",\n      \"product\": {\n        \"type\": \"LatteDrinks\",\n        \"name\": \"latte\",\n        \"temperature\": \"iced\",\n        \"size\": \"venti\"\n      },\n      \"quantity\": 1\n    }\n  ]\n}";
+        var cart = json.FromJson<Cart>();
+        Assert.That(cart.Items.Count, Is.EqualTo(1));
+        Assert.That(cart.Items[0].Product.Type, Is.EqualTo("LatteDrinks"));
+        Assert.That(cart.Items[0].Product.Name, Is.EqualTo("latte"));
+        Assert.That(cart.Items[0].Product.Temperature, Is.EqualTo("iced"));
+        
+    }
 }

--- a/CoffeeShop/Configure.AppHost.cs
+++ b/CoffeeShop/Configure.AppHost.cs
@@ -37,6 +37,8 @@ public class AppHost : AppHostBase, IHostingStartup
         Plugins.Add(new CorsFeature(new[] {
             "http://localhost:5173", //vite dev
         }, allowCredentials:true));
+        
+        Plugins.Add(new ProfilingFeature());
 
         if (!AppTasks.IsRunAsAppTask())
         {

--- a/CoffeeShop/ConfigureGpt.cs
+++ b/CoffeeShop/ConfigureGpt.cs
@@ -1,4 +1,5 @@
 ﻿using CoffeeShop.ServiceInterface;
+using CoffeeShop.ServiceModel;
 using Microsoft.SemanticKernel;
 
 [assembly: HostingStartup(typeof(CoffeeShop.ConfigureGpt))]
@@ -12,7 +13,7 @@ public class ConfigureGpt : IHostingStartup
         {
             // Call Open AI Chat API directly without going through node TypeChat
             var gptProvider = context.Configuration.GetValue<string>("GptChatProvider");
-            if (gptProvider == nameof(KernelGptCoffeeShop))
+            if (gptProvider == nameof(KernelChatProvider<Cart>))
             {
                 var kernel = Kernel.Builder
                     .WithOpenAIChatCompletionService(
@@ -20,14 +21,14 @@ public class ConfigureGpt : IHostingStartup
                         Environment.GetEnvironmentVariable("OPENAI_API_KEY")!)
                     .Build();
                 services.AddSingleton(kernel);
-                services.AddSingleton<IGptCoffeeShop>(c => 
-                    new KernelGptCoffeeShop(c.Resolve<AppConfig>(), c.Resolve<IKernel>()));
+                services.AddSingleton<ITypeChatProvider<Cart>>(c => 
+                    new KernelChatProvider<Cart>(c.Resolve<AppConfig>(), c.Resolve<IKernel>()));
             }
-            else if (gptProvider == nameof(NodeTypeChatGptCoffeeShop))
+            else if (gptProvider == nameof(NodeTypeChatProvider<Cart>))
             {
                 // Call Open AI Chat API through node TypeChat
-                services.AddSingleton<IGptCoffeeShop>(c =>
-                    new NodeTypeChatGptCoffeeShop(c.Resolve<AppConfig>()));
+                services.AddSingleton<ITypeChatProvider<Cart>>(c =>
+                    new NodeTypeChatProvider<Cart>(c.Resolve<AppConfig>()));
             }
             else throw new NotSupportedException($"Unknown GptChatProvider: {gptProvider}");
         });

--- a/CoffeeShop/ConfigureVfs.cs
+++ b/CoffeeShop/ConfigureVfs.cs
@@ -26,7 +26,7 @@ public class ConfigureVfs : IHostingStartup
             if (appHost.Container.Exists<StorageClient>())
             {
                 appHost.VirtualFiles = new GoogleCloudVirtualFiles(
-                    appHost.Resolve<StorageClient>(), appHost.Resolve<AppConfig>().CoffeeShop.Bucket);
+                    appHost.Resolve<StorageClient>(), appHost.Resolve<AppConfig>().SiteConfig.Bucket);
             }
         });
 }

--- a/CoffeeShop/Pages/Index.cshtml
+++ b/CoffeeShop/Pages/Index.cshtml
@@ -621,6 +621,7 @@ const App = {
             console.log('processChatResponse', items)
             const addedProducts = []
             items.forEach(item => {
+                console.log(item)
                 if (item.type.toLowerCase() !== "lineitem") {
                     console.warn(`ignoring unknown lineItem type ${item.type}`)
                     return
@@ -638,6 +639,7 @@ const App = {
                 const temperature = !category.temperatures || !item.temperature
                     ? null
                     : category.temperatures.find(x => x.toLowerCase() === item.temperature.toLowerCase())
+                console.log(temperature)
                 if (temperature) {
                     orderItem.temperature = temperature
                 }

--- a/CoffeeShop/appsettings.json
+++ b/CoffeeShop/appsettings.json
@@ -15,15 +15,15 @@
     "options": {
         "VfsProvider": ["GoogleCloudVirtualFiles", "FileSystemVirtualFiles"],
         "SpeechProvider": ["GoogleCloudSpeechToText", "WhisperLocalSpeechToText", "WhisperApiSpeechToText"],
-        "GptChatProvider": ["NodeTypeChatGptCoffeeShop", "KernelGptCoffeeShop"]
+        "GptChatProvider": ["NodeTypeChatProvider", "KernelChatProvider"]
     },
     "VfsProvider": "FileSystemVirtualFiles",
     "SpeechProvider": "WhisperApiSpeechToText",
-    "GptChatProvider": "NodeTypeChatGptCoffeeShop",
+    "GptChatProvider": "NodeTypeChatProvider",
     "AppConfig": {
         "Project": "servicestackdemo",
         "Location": "global",
-        "CoffeeShop": {
+        "SiteConfig": {
             "GptPath": "gpt/coffeeshop",
             "Bucket": "servicestack-coffeeshop",
             "RecognizerId": "coffeeshop-recognizer",

--- a/CoffeeShop/typechat.mjs
+++ b/CoffeeShop/typechat.mjs
@@ -10,11 +10,7 @@ const model = createLanguageModel(process.env)
 //const schema = await fs.readFile(path.join(__dirname, "coffeeShopSchema.ts"), "utf8")
 const schema = await fs.readFile(path.join(__dirname, process.argv[2]), "utf8")
 
-const firstInterfacePos = schema.indexOf('export interface ')
-const endPos = schema.indexOf('{', firstInterfacePos)
-const schemaName = schema.substring(firstInterfacePos + 'export interface '.length, endPos).trim()
-
-const translator = createJsonTranslator(model, schema, schemaName)
+const translator = createJsonTranslator(model, schema, process.argv[4])
 
 const response = await translator.translate(process.argv[3])
 if (!response.success) {


### PR DESCRIPTION
I've changed the use of the Kernel and NodeTypeChat providers into using generics to match the types used in TypeChat.

This approach seemed to work well for Semantic and Calendar examples, so I moved into here into here to give another example of usage. 

This still uses an `AppConfig`  which could be put into a plugin for Google/Whisper etc instead of AppSettings or something else. 

The `Location` could be derived from the TypeName used. In this case `Cart` matching the TypeScript type of the response.

Here is an example configuration usage from the `Configure.Gpt`

```csharp
    public void Configure(IWebHostBuilder builder) => builder
        .ConfigureServices((context, services) =>
        {
            // Call Open AI Chat API directly without going through node TypeChat
            var gptProvider = context.Configuration.GetValue<string>("GptChatProvider");
            if (gptProvider == nameof(KernelChatProvider<Cart>))
            {
                var kernel = Kernel.Builder
                    .WithOpenAIChatCompletionService(
                        Environment.GetEnvironmentVariable("OPENAI_MODEL")!, 
                        Environment.GetEnvironmentVariable("OPENAI_API_KEY")!)
                    .Build();
                services.AddSingleton(kernel);
                services.AddSingleton<ITypeChatProvider<Cart>>(c => 
                    new KernelChatProvider<Cart>(c.Resolve<AppConfig>(), c.Resolve<IKernel>()));
            }
            else if (gptProvider == nameof(NodeTypeChatProvider<Cart>))
            {
                // Call Open AI Chat API through node TypeChat
                services.AddSingleton<ITypeChatProvider<Cart>>(c =>
                    new NodeTypeChatProvider<Cart>(c.Resolve<AppConfig>()));
            }
            else throw new NotSupportedException($"Unknown GptChatProvider: {gptProvider}");
        });
```

The `ITypeChatProvider` is then used with an `IGptRequest` which can be used as the 'chat' entry point service.

```csharp
public class GptRequestBase<T> : IGptRequest<T>
{
    public string UserRequest { get; set; }
    public Dictionary<string,object>? PromptContext { get; set; }
}

public interface IGptRequest<T> : IReturn<T>
{
    string UserRequest { get; set; }
    Dictionary<string,object>? PromptContext { get; set; }
}
```

I've used `ProcessCartRequest` like so, which can be populated with the object dictionary for SharpScript.

```csharp
public class ProcessCartRequest : GptRequestBase<Cart> {}

public async Task<object> Any(CreateCoffeeShopChat request)
{
 ...
            var categories = await Db.LoadSelectAsync(Db.From<Category>());
            var options = await Db.SelectAsync<Option>();
            var optionsMap = options.ToDictionary(x => x.Id);
            var optionQuantities = await Db.SelectAsync<OptionQuantity>();
            
            var gptRequest = new ProcessCartRequest()
            {
                UserRequest = request.Request,
                PromptContext = new Dictionary<string, object>
                {
                    [nameof(categories)] = categories,
                    [nameof(options)] = options,
                    [nameof(optionsMap)] = optionsMap,
                    [nameof(optionQuantities)] = optionQuantities,
                },
            };
            var result = await GptCoffeeShop.ProcessAsync(gptRequest);
}
```

There is probably a way to integrate with AutoQuery requests in a better way or skipping the use of `IReturn<T>` in the `IGptRequest` so they aren't bound together. The reason I put them together was mainly to have one less Request DTO for easy Locode usage, but that does make examples like the Coffeeshop a bit more awkward. 

This is just an idea for an approach. 

I also think there is an issue with the web client handling of options like `iced` drinks as they are getting picked up correctly in the LLM response, but it is always defaulting to `Hot`. 



